### PR TITLE
test: add coverage batch 1 (46% -> 57%) + track main in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 # Least-privilege by default.

--- a/tests/test_consumer/test_cef.py
+++ b/tests/test_consumer/test_cef.py
@@ -1,6 +1,53 @@
 from unittest import TestCase
 
-from duologsync.consumer.cef import _construct_extension
+from duologsync.config import Config
+from duologsync.consumer.cef import _construct_extension, log_to_cef
+
+
+class TestLogToCef(TestCase):
+    def test_auth_log_header_and_extension(self):
+        keys_to_labels = {
+            ("eventtype",): {"name": "cat", "is_custom": False},
+            ("username",): {"name": "suser", "is_custom": False},
+        }
+        log = {"eventtype": "authentication", "username": "alice"}
+
+        cef = log_to_cef(log, keys_to_labels, Config.AUTH)
+
+        # Prefix fields are pipe-delimited; the CEF message contains the header.
+        self.assertIn("CEF:0|Duo Security|DuoLogSync|", cef)
+        # signature_id and name both come from eventtype for non-activity logs.
+        self.assertIn("|authentication|authentication|5|", cef)
+        self.assertIn("cat=authentication", cef)
+        self.assertIn("suser=alice", cef)
+
+    def test_administrator_event_uses_action_as_name(self):
+        keys_to_labels = {("eventtype",): {"name": "cat", "is_custom": False}}
+        log = {"eventtype": "administrator", "action": "admin_login"}
+        cef = log_to_cef(log, keys_to_labels, Config.AUTH)
+        # For 'administrator' eventtype, the CEF name field is the action.
+        self.assertIn("|administrator|admin_login|5|", cef)
+
+    def test_activity_log_uses_action_and_actor(self):
+        keys_to_labels = {("result",): {"name": "outcome", "is_custom": False}}
+        log = {
+            "action": {"name": "create_user"},
+            "actor": {"type": "admin"},
+            "result": "success",
+        }
+        cef = log_to_cef(log, keys_to_labels, Config.ACTIVITY)
+        self.assertIn("|create_user|admin|5|", cef)
+        self.assertIn("outcome=success", cef)
+
+    def test_custom_label_emits_label_pair(self):
+        keys_to_labels = {
+            ("application", "name"): {"name": "integration_name", "is_custom": True},
+        }
+        log = {"application": {"name": "MyApp"}, "eventtype": "authentication"}
+        cef = log_to_cef(log, keys_to_labels, Config.AUTH)
+        # Custom fields emit a csNLabel=<name> pair plus csN=<value>.
+        self.assertIn("cs1Label=integration_name", cef)
+        self.assertIn("cs1=MyApp", cef)
 
 
 class TestCef(TestCase):

--- a/tests/test_consumer_format.py
+++ b/tests/test_consumer_format.py
@@ -1,0 +1,45 @@
+"""
+Unit tests for Consumer.format_log — the JSON / CEF formatting and the
+unsupported-format guard. These are pure formatting paths that require no
+network, queue, or Config singleton.
+"""
+
+from unittest import TestCase
+
+from duologsync.config import Config
+from duologsync.consumer.consumer import Consumer
+
+
+def _consumer(log_format):
+    return Consumer(log_format=log_format, log_queue=None, writer=None)
+
+
+class TestFormatLog(TestCase):
+    def test_json_format_returns_encoded_newline_terminated_bytes(self):
+        consumer = _consumer(Config.JSON)
+        result = consumer.format_log({"event": 1, "type": "auth"})
+        self.assertIsInstance(result, bytes)
+        self.assertTrue(result.endswith(b"\n"))
+        self.assertEqual(result, b'{"event": 1, "type": "auth"}\n')
+
+    def test_cef_format_produces_cef_header(self):
+        consumer = _consumer(Config.CEF)
+        consumer.log_type = Config.AUTH
+        consumer.keys_to_labels = {("eventtype",): {"name": "cat", "is_custom": False}}
+
+        result = consumer.format_log({"eventtype": "login"}).decode("utf-8")
+        self.assertIn("CEF:0|Duo Security|DuoLogSync|", result)
+        # signature_id and name both derive from eventtype for non-activity logs.
+        self.assertIn("|login|login|", result)
+        self.assertIn("cat=login", result)
+
+    def test_cef_bytes_are_newline_terminated(self):
+        consumer = _consumer(Config.CEF)
+        consumer.log_type = Config.AUTH
+        result = consumer.format_log({"eventtype": "login"})
+        self.assertTrue(result.endswith(b"\n"))
+
+    def test_unsupported_format_raises_value_error(self):
+        consumer = _consumer("XML")
+        with self.assertRaises(ValueError):
+            consumer.format_log({"event": 1})

--- a/tests/test_producer_error_handling.py
+++ b/tests/test_producer_error_handling.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for Producer error/retry helpers: eligible_for_retry (the
+retry-on-429 gate), handle_os_error, handle_address_info_error, and
+handle_runtime_error_gracefully. Producer.__new__ is used to exercise these
+pure methods without the network-touching __init__.
+"""
+
+import socket
+from unittest import TestCase
+
+from duologsync.config import Config
+from duologsync.producer.producer import Producer
+from duologsync.program import Program
+
+
+def _producer(log_type="auth"):
+    producer = Producer.__new__(Producer)
+    producer.log_type = log_type
+    return producer
+
+
+class TestEligibleForRetry(TestCase):
+    def test_429_is_eligible(self):
+        # GRACEFUL_RETRY_STATUS_CODES contains 429 (TOO_MANY_REQUESTS).
+        self.assertTrue(Producer.eligible_for_retry(429))
+
+    def test_other_codes_not_eligible(self):
+        self.assertFalse(Producer.eligible_for_retry(500))
+        self.assertFalse(Producer.eligible_for_retry(200))
+
+    def test_none_not_eligible(self):
+        self.assertFalse(Producer.eligible_for_retry(None))
+
+
+class TestHandleOsError(TestCase):
+    def test_includes_message_code_and_filename(self):
+        producer = _producer("auth")
+        message = producer.handle_os_error(FileNotFoundError(28, "No space left on device", "/var/log/x"))
+        self.assertIn("No space left on device", message)
+        self.assertIn("error_code: 28", message)
+        self.assertIn("file_name: /var/log/x", message)
+        self.assertTrue(message.startswith("auth producer:"))
+
+
+class TestHandleAddressInfoError(TestCase):
+    def setUp(self):
+        Config.set_config({"config_file_path": "/etc/duologsync/config.yml"})
+
+    def tearDown(self):
+        Config._config = None
+        Config._config_is_set = False
+
+    def test_returns_message_with_code(self):
+        producer = _producer("telephony")
+        message = producer.handle_address_info_error(socket.gaierror(8, "nodename nor servname provided"))
+        self.assertIn("nodename nor servname provided", message)
+        self.assertIn("error_code: 8", message)
+        self.assertTrue(message.startswith("telephony producer:"))
+
+
+class TestHandleRuntimeErrorGracefully(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    def _runtime_error(self, status, code=40000):
+        error = RuntimeError("api failure")
+        error.status = status
+        error.data = {"code": code}
+        return error
+
+    def test_retryable_status_returns_none(self):
+        producer = _producer("auth")
+        result = producer.handle_runtime_error_gracefully(self._runtime_error(429))
+        # None signals "retry", not "shut down".
+        self.assertIsNone(result)
+
+    def test_non_retryable_status_returns_shutdown_reason(self):
+        producer = _producer("auth")
+        result = producer.handle_runtime_error_gracefully(self._runtime_error(500))
+        self.assertIsNotNone(result)
+        self.assertIn("http_status_code: 500", result)
+        self.assertIn("error_code: 40000", result)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for duologsync.util helpers: extract_error_info (the shared error
+helper used across writer/consumer/producer), check_for_specific_endpoint,
+and store_failed_udp_ingestion_logs.
+"""
+
+import socket
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from duologsync.util import (
+    check_for_specific_endpoint,
+    extract_error_info,
+    store_failed_udp_ingestion_logs,
+)
+
+
+class TestExtractErrorInfo(TestCase):
+    def test_oserror_with_errno_and_strerror(self):
+        info = extract_error_info(OSError(32, "Broken pipe"))
+        self.assertEqual(info["error_code"], 32)
+        self.assertEqual(info["error_message"], "Broken pipe")
+
+    def test_gaierror_is_supported(self):
+        # socket.gaierror is an OSError subclass carrying errno/strerror.
+        info = extract_error_info(socket.gaierror(8, "nodename nor servname provided"))
+        self.assertEqual(info["error_code"], 8)
+        self.assertEqual(info["error_message"], "nodename nor servname provided")
+
+    def test_falls_back_to_two_arg_tuple(self):
+        # A bare Exception has no errno/strerror; two args map to code+message.
+        info = extract_error_info(Exception(42, "custom failure"))
+        self.assertEqual(info["error_code"], 42)
+        self.assertEqual(info["error_message"], "custom failure")
+
+    def test_falls_back_to_single_arg_message(self):
+        info = extract_error_info(Exception("just a message"))
+        self.assertIsNone(info["error_code"])
+        self.assertEqual(info["error_message"], "just a message")
+
+    def test_no_args_yields_none(self):
+        info = extract_error_info(Exception())
+        self.assertIsNone(info["error_code"])
+        self.assertIsNone(info["error_message"])
+
+    def test_extra_attrs_are_included(self):
+        # OSError(errno, strerror, filename) populates the .filename attribute.
+        error = FileNotFoundError(2, "No such file or directory", "/tmp/missing.pem")
+        info = extract_error_info(error, "filename")
+        self.assertEqual(info["error_code"], 2)
+        self.assertEqual(info["error_message"], "No such file or directory")
+        self.assertEqual(info["filename"], "/tmp/missing.pem")
+
+    def test_missing_extra_attr_is_none(self):
+        info = extract_error_info(OSError(1, "op not permitted"), "filename")
+        self.assertIsNone(info["filename"])
+
+
+class TestCheckForSpecificEndpoint(TestCase):
+    @staticmethod
+    def _config(*endpoint_lists):
+        return {"account": {"endpoint_server_mappings": [{"endpoints": list(e)} for e in endpoint_lists]}}
+
+    def test_endpoint_present(self):
+        config = self._config(["auth", "telephony"], ["activity"])
+        self.assertTrue(check_for_specific_endpoint("auth", config))
+        self.assertTrue(check_for_specific_endpoint("activity", config))
+
+    def test_endpoint_absent(self):
+        config = self._config(["auth"])
+        self.assertFalse(check_for_specific_endpoint("trustmonitor", config))
+
+    def test_no_mappings(self):
+        self.assertFalse(check_for_specific_endpoint("auth", {"account": {}}))
+        self.assertFalse(check_for_specific_endpoint("auth", {}))
+
+
+class TestStoreFailedUdpIngestionLogs(TestCase):
+    def test_appends_decoded_payload_to_backlog_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store_failed_udp_ingestion_logs("auth", directory, b'{"event": 1}\n')
+            store_failed_udp_ingestion_logs("auth", directory, b'{"event": 2}\n')
+
+            backlog = Path(directory) / "auth_udp_failed_ingestion_logs.txt"
+            self.assertTrue(backlog.exists())
+            self.assertEqual(
+                backlog.read_text(),
+                '{"event": 1}\n{"event": 2}\n',
+            )

--- a/tests/test_writer_file_async.py
+++ b/tests/test_writer_file_async.py
@@ -1,0 +1,134 @@
+"""
+Tests for the asynchronous LocalFileWriter pipeline: end-to-end write via the
+queue/worker, the retry-with-backoff path, disk-full detection triggering
+shutdown, and crash-safe backlog replay on startup.
+
+Async is driven with a fresh event loop per test (no pytest-asyncio needed);
+the writer is constructed inside the coroutine so its Queue/Locks bind to the
+running loop across Python 3.8-3.13.
+"""
+
+import asyncio
+import errno
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from duologsync.program import Program
+from duologsync.writer import LocalFileWriter
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _writer(directory, **overrides):
+    params = {
+        "filepath": str(Path(directory) / "out.log"),
+        "checkpoint_directory": directory,
+        "queue_max_size": 100,
+        "max_retries": 3,
+        "retry_backoff_seconds": 0,
+        "enable_test_input": False,
+        "rotation": "none",
+    }
+    params.update(overrides)
+    return LocalFileWriter(**params)
+
+
+class TestLocalFileWriterAsync(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    def test_end_to_end_write_and_shutdown(self):
+        with tempfile.TemporaryDirectory() as directory:
+
+            async def scenario():
+                writer = _writer(directory)
+                writer.register_log_type("auth")
+                await writer.start()
+                for index in range(5):
+                    await writer.write(f"log-{index}\n".encode("utf-8"), "auth")
+                await writer.shutdown()
+                return writer.filepath
+
+            filepath = run(scenario())
+            self.assertEqual(filepath.read_bytes().count(b"\n"), 5)
+
+    def test_write_retries_then_succeeds(self):
+        with tempfile.TemporaryDirectory() as directory:
+
+            async def scenario():
+                writer = _writer(directory, max_retries=3)
+                state = {"attempts": 0}
+
+                def flaky(data):
+                    state["attempts"] += 1
+                    if state["attempts"] < 3:
+                        raise OSError(errno.EIO, "I/O error")
+                    with open(writer.filepath, "ab") as handle:
+                        handle.write(data)
+
+                writer._write_to_file = flaky
+                ok, should_backlog = await writer._write_with_retries(b"x\n", "auth")
+                return ok, should_backlog, state["attempts"], writer.filepath.read_bytes()
+
+            ok, should_backlog, attempts, contents = run(scenario())
+            self.assertTrue(ok)
+            self.assertFalse(should_backlog)
+            self.assertEqual(attempts, 3)
+            self.assertEqual(contents, b"x\n")
+
+    def test_write_exhausts_retries_and_requests_backlog(self):
+        with tempfile.TemporaryDirectory() as directory:
+
+            async def scenario():
+                writer = _writer(directory, max_retries=2)
+
+                def always_fail(data):
+                    raise OSError(errno.EIO, "I/O error")
+
+                writer._write_to_file = always_fail
+                return await writer._write_with_retries(b"x\n", "auth")
+
+            ok, should_backlog = run(scenario())
+            self.assertFalse(ok)
+            # Non-disk-full failures should be spilled to the backlog.
+            self.assertTrue(should_backlog)
+
+    def test_disk_full_triggers_shutdown(self):
+        with tempfile.TemporaryDirectory() as directory:
+
+            async def scenario():
+                writer = _writer(directory)
+
+                def no_space(data):
+                    raise OSError(errno.ENOSPC, "No space left on device")
+
+                writer._write_to_file = no_space
+                return await writer._write_with_retries(b"x\n", "auth")
+
+            ok, should_backlog = run(scenario())
+            self.assertFalse(ok)
+            # Disk-full must NOT backlog (there's no space) — it shuts down.
+            self.assertFalse(should_backlog)
+            self.assertFalse(Program.is_running())
+
+    def test_backlog_is_replayed_on_startup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            backlog = Path(directory) / "auth_file_failed_ingestion_logs.txt"
+            backlog.write_bytes(b"replayed-1\nreplayed-2\n")
+
+            async def scenario():
+                writer = _writer(directory)
+                await writer._replay_backlog("auth")
+                return writer.filepath, backlog
+
+            filepath, backlog_path = run(scenario())
+            self.assertEqual(filepath.read_bytes(), b"replayed-1\nreplayed-2\n")
+            self.assertFalse(backlog_path.exists())
+            self.assertFalse(Path(f"{backlog_path}.replay").exists())

--- a/tests/test_writer_network.py
+++ b/tests/test_writer_network.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for the network Writer.write dispatch and its error handling:
+- UDP: OSError on sendto is caught and the payload spilled to a backlog file.
+- TCP/TCPSSL: OSError on write/drain is logged and re-raised to the consumer.
+
+Writer.__new__ is used with stub underlying writers so no real sockets are
+opened (Writer.__init__ synchronously connects, which is unsuitable here).
+"""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from duologsync.config import Config
+from duologsync.program import Program
+from duologsync.writer import Writer
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _FakeUdpSocket:
+    def __init__(self, error=None):
+        self.error = error
+        self.sent = []
+
+    def sendto(self, data, addr):
+        if self.error:
+            raise self.error
+        self.sent.append((data, addr))
+
+
+class _FakeStream:
+    def __init__(self, drain_error=None):
+        self.drain_error = drain_error
+        self.written = []
+        self.drained = False
+
+    def write(self, data):
+        self.written.append(data)
+
+    async def drain(self):
+        if self.drain_error:
+            raise self.drain_error
+        self.drained = True
+
+
+def _writer(protocol, underlying, hostname="127.0.0.1", port=8888):
+    writer = Writer.__new__(Writer)
+    writer.protocol = protocol
+    writer.hostname = hostname
+    writer.port = port
+    writer.writer = underlying
+    return writer
+
+
+class TestUdpWrite(TestCase):
+    def tearDown(self):
+        Config._config = None
+        Config._config_is_set = False
+        Program._running = True
+
+    def test_udp_success_calls_sendto(self):
+        sock = _FakeUdpSocket()
+        writer = _writer("UDP", sock)
+        run(writer.write(b"payload\n", "auth"))
+        self.assertEqual(sock.sent, [(b"payload\n", ("127.0.0.1", 8888))])
+
+    def test_udp_oserror_spills_to_backlog(self):
+        with tempfile.TemporaryDirectory() as directory:
+            Config.set_config({"dls_settings": {"checkpointing": {"directory": directory}}})
+            sock = _FakeUdpSocket(error=OSError(90, "Message too long"))
+            writer = _writer("UDP", sock)
+
+            # Must not raise — UDP failures are spilled, not propagated.
+            run(writer.write(b"lost-log\n", "auth"))
+
+            backlog = Path(directory) / "auth_udp_failed_ingestion_logs.txt"
+            self.assertTrue(backlog.exists())
+            self.assertEqual(backlog.read_text(), "lost-log\n")
+
+
+class TestTcpWrite(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    def test_tcp_success_writes_and_drains(self):
+        stream = _FakeStream()
+        writer = _writer("TCP", stream)
+        run(writer.write(b"payload\n", "auth"))
+        self.assertEqual(stream.written, [b"payload\n"])
+        self.assertTrue(stream.drained)
+
+    def test_tcp_oserror_is_reraised(self):
+        stream = _FakeStream(drain_error=OSError(32, "Broken pipe"))
+        writer = _writer("TCP", stream)
+        with self.assertRaises(OSError):
+            run(writer.write(b"payload\n", "auth"))


### PR DESCRIPTION
## Summary

First batch of the missing-tests work identified in the coverage review. Raises coverage from **~46% → ~57%** and the suite from **65 → 100 tests**, focused on the highest-risk previously-untested paths (durability, connection errors, the shared error helper, and formatters).

Also includes a one-line CI fix: the workflow `push` trigger now tracks `main` after the default-branch rename from `master`.

## New tests

- **`test_util.py`** — `extract_error_info` across all arg shapes + extra attrs (the shared error helper adopted across writer/consumer/producer), plus `check_for_specific_endpoint` and `store_failed_udp_ingestion_logs`.
- **`test_writer_file_async.py`** — the async `LocalFileWriter` pipeline: end-to-end write/shutdown, retry-with-backoff, retry-exhaustion → backlog, disk-full (`ENOSPC`) → graceful shutdown, and crash-safe backlog replay on startup.
- **`test_writer_network.py`** — network `Writer.write` dispatch: UDP `OSError` → spill, TCP write/drain `OSError` → re-raise, and success paths.
- **`test_consumer_format.py`** — `Consumer.format_log` for JSON/CEF and the unsupported-format `ValueError` guard.
- **`test_consumer/test_cef.py`** — `log_to_cef` header + extension for auth/activity, administrator name handling, custom-label pairs (`cef.py` 48% → 97%).
- **`test_producer_error_handling.py`** — `eligible_for_retry` (429 gate) and the three `handle_*` error methods.

Async tests drive a per-test event loop, so no new test dependency (e.g. pytest-asyncio) is required.

## Coverage delta (per module)

| Module | Before | After |
|---|---|---|
| `consumer/cef.py` | 48% | 97% |
| `writer.py` | 37% | 57% |
| `producer/producer.py` | 44% | 58% |
| `util.py` | 23% | 46% |
| `consumer/consumer.py` | 23% | 39% |
| **Total** | **46%** | **57%** |

Still open for a future batch: the `consume()` loop, producer `produce()`/`call_log_api`, `app.py` wiring, and `service.py` (Windows-only).

## Testing
- `uv run pytest` → **100 passed**.
- `uv run ruff check .` and `uv run ruff format --check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
