### PR TITLE
test: raise coverage to ~94% and enforce a 90% CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
       - name: Run tests
-        run: uv run pytest --cov=duologsync --cov-report=xml --cov-report=term-missing
+        run: uv run pytest --cov=duologsync --cov-report=xml --cov-report=term-missing --cov-fail-under=90
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4

--- a/duologsync/service.py
+++ b/duologsync/service.py
@@ -174,5 +174,5 @@ def main():
         win32serviceutil.HandleCommandLine(DuoLogSyncService)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
+exclude_also = [
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/test_app_more.py
+++ b/tests/test_app_more.py
@@ -1,0 +1,161 @@
+"""
+Coverage for app.py: signal_handler, main() dispatch, run() branches, and
+create_consumer_producer_pair for every endpoint. Producer/consumer classes,
+asyncio, and Config are patched so nothing touches a real event loop or API.
+"""
+
+import signal
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from duologsync import app
+from duologsync.app import create_consumer_producer_pair, main, run, signal_handler
+from duologsync.config import Config
+from duologsync.program import Program
+
+
+class TestSignalHandler(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    @patch("duologsync.app.Program")
+    def test_sigint(self, program):
+        signal_handler(signal.SIGINT, None)
+        reason = program.initiate_shutdown.call_args.args[0]
+        self.assertIn("Ctrl-C", reason)
+        program.log.assert_not_called()
+
+    @patch("duologsync.app.Program")
+    def test_sigterm_with_stack_frame(self, program):
+        signal_handler(signal.SIGTERM, "frame")
+        program.initiate_shutdown.assert_called_once()
+        program.log.assert_called_once()
+
+
+class TestMain(TestCase):
+    @patch("duologsync.app._validate_and_exit")
+    def test_validate_branch(self, validate):
+        with patch.object(sys, "argv", ["duologsync", "cfg.yml", "--validate"]):
+            main()
+        validate.assert_called_once_with("cfg.yml")
+
+    @patch("duologsync.app.run")
+    @patch("duologsync.app.signal.signal")
+    def test_normal_branch(self, _signal, run_mock):
+        with patch.object(sys, "argv", ["duologsync", "cfg.yml"]):
+            main()
+        run_mock.assert_called_once_with("cfg.yml")
+
+
+class TestValidateAndExit(TestCase):
+    @patch("duologsync.app.Config.validate_config", return_value=([], ["low timeout"]))
+    def test_warnings_only_exits_zero(self, _validate):
+        with self.assertRaises(SystemExit) as ctx:
+            app._validate_and_exit("cfg.yml")
+        self.assertEqual(ctx.exception.code, 0)
+
+
+class TestRun(TestCase):
+    @patch("duologsync.app.Writer")
+    @patch("duologsync.app.Program")
+    @patch("duologsync.app.check_for_specific_endpoint", return_value=True)
+    @patch("duologsync.app.Config")
+    def test_dtm_non_json_early_return(self, config, _dtm, _program, writer):
+        config.create_config.return_value = {}
+        config.get_log_format.return_value = "CEF"
+        config.account_is_msp.return_value = False
+        run("cfg.yml")
+        writer.create_writers.assert_not_called()
+
+    @patch("duologsync.app.Writer")
+    @patch("duologsync.app.Program")
+    @patch("duologsync.app.check_for_specific_endpoint", return_value=True)
+    @patch("duologsync.app.Config")
+    def test_dtm_msp_early_return(self, config, _dtm, _program, writer):
+        config.create_config.return_value = {}
+        config.get_log_format.return_value = "JSON"
+        config.account_is_msp.return_value = True
+        run("cfg.yml")
+        writer.create_writers.assert_not_called()
+
+    @patch("duologsync.app.asyncio")
+    @patch("duologsync.app.create_tasks", return_value=[])
+    @patch("duologsync.app.Writer")
+    @patch("duologsync.app.Program")
+    @patch("duologsync.app.check_for_specific_endpoint", return_value=False)
+    @patch("duologsync.app.Config")
+    def test_full_path_runs_event_loop(self, config, _dtm, program, writer, create_tasks, _asyncio):
+        config.create_config.return_value = {}
+        config.get_log_format.return_value = "JSON"
+        config.account_is_msp.return_value = False
+        config.get_servers.return_value = []
+        program.is_logging_set.return_value = False
+        run("cfg.yml")
+        writer.create_writers.assert_called_once()
+        create_tasks.assert_called_once()
+        _asyncio.get_event_loop.return_value.run_until_complete.assert_called()
+
+
+class TestCreateConsumerProducerPair(TestCase):
+    def setUp(self):
+        Config.set_config({"dls_settings": {"log_format": "JSON"}, "account": {"is_msp": False}})
+
+    def tearDown(self):
+        Config._config = None
+        Config._config_is_set = False
+
+    @patch("duologsync.app.asyncio.ensure_future", return_value="TASK")
+    @patch("duologsync.app.AuthlogConsumer")
+    @patch("duologsync.app.AuthlogProducer")
+    def test_auth_non_msp(self, producer, consumer, _ensure):
+        writer = MagicMock()
+        tasks = create_consumer_producer_pair(Config.AUTH, writer, MagicMock())
+        producer.assert_called_once()
+        consumer.assert_called_once()
+        self.assertEqual(tasks, ["TASK", "TASK"])
+        writer.register_log_type.assert_called_once_with(Config.AUTH)
+
+    @patch("duologsync.app.asyncio.ensure_future", return_value="TASK")
+    @patch("duologsync.app.AuthlogConsumer")
+    @patch("duologsync.app.AuthlogProducer")
+    @patch("duologsync.app.Config.account_is_msp", return_value=True)
+    def test_auth_msp_uses_json_api(self, _msp, producer, _consumer, _ensure):
+        create_consumer_producer_pair(Config.AUTH, MagicMock(), MagicMock(), child_account="c1")
+        self.assertEqual(producer.call_args.kwargs["url_path"], "/admin/v2/logs/authentication")
+
+    @patch("duologsync.app.asyncio.ensure_future", return_value="TASK")
+    @patch("duologsync.app.TelephonyConsumer")
+    @patch("duologsync.app.TelephonyProducer")
+    def test_telephony(self, producer, consumer, _ensure):
+        tasks = create_consumer_producer_pair(Config.TELEPHONY, MagicMock(), MagicMock())
+        producer.assert_called_once()
+        self.assertEqual(len(tasks), 2)
+
+    @patch("duologsync.app.asyncio.ensure_future", return_value="TASK")
+    @patch("duologsync.app.TrustMonitorConsumer")
+    @patch("duologsync.app.TrustMonitorProducer")
+    def test_trustmonitor(self, producer, _consumer, _ensure):
+        tasks = create_consumer_producer_pair(Config.TRUST_MONITOR, MagicMock(), MagicMock())
+        producer.assert_called_once()
+        self.assertEqual(len(tasks), 2)
+
+    @patch("duologsync.app.asyncio.ensure_future", return_value="TASK")
+    @patch("duologsync.app.ActivityConsumer")
+    @patch("duologsync.app.ActivityProducer")
+    def test_activity(self, producer, _consumer, _ensure):
+        tasks = create_consumer_producer_pair(Config.ACTIVITY, MagicMock(), MagicMock())
+        producer.assert_called_once()
+        self.assertEqual(len(tasks), 2)
+
+    def test_unrecognized_endpoint_returns_empty(self):
+        tasks = create_consumer_producer_pair("bogus", MagicMock(), MagicMock())
+        self.assertEqual(tasks, [])
+
+    @patch("duologsync.app.asyncio.ensure_future", return_value="TASK")
+    @patch("duologsync.app.TelephonyConsumer")
+    @patch("duologsync.app.TelephonyProducer")
+    def test_writer_without_register_log_type(self, _producer, _consumer, _ensure):
+        # A plain object has no register_log_type attribute -> hasattr False branch.
+        tasks = create_consumer_producer_pair(Config.TELEPHONY, object(), MagicMock())
+        self.assertEqual(len(tasks), 2)

--- a/tests/test_consumer/test_subclasses.py
+++ b/tests/test_consumer/test_subclasses.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for the consumer subclass constructors — each wires the right
+log_type and keys-to-labels mapping and inherits the base Consumer attributes.
+"""
+
+from unittest import TestCase
+
+from duologsync.config import Config
+from duologsync.consumer.activity_consumer import ACTIVITY_KEYS_TO_LABELS, ActivityConsumer
+from duologsync.consumer.authlog_consumer import AUTHLOG_KEYS_TO_LABELS, AuthlogConsumer
+from duologsync.consumer.telephony_consumer import TELEPHONY_KEYS_TO_LABELS, TelephonyConsumer
+from duologsync.consumer.trustmonitor_consumer import TrustMonitorConsumer
+
+
+class TestConsumerSubclasses(TestCase):
+    def test_authlog_consumer(self):
+        consumer = AuthlogConsumer(Config.JSON, "queue", "writer", child_account_id="c1")
+        self.assertEqual(consumer.log_type, Config.AUTH)
+        self.assertIs(consumer.keys_to_labels, AUTHLOG_KEYS_TO_LABELS)
+        self.assertEqual(consumer.log_format, Config.JSON)
+        self.assertEqual(consumer.child_account_id, "c1")
+        self.assertIsNone(consumer.log_offset)
+
+    def test_telephony_consumer(self):
+        consumer = TelephonyConsumer(Config.CEF, "queue", "writer")
+        self.assertEqual(consumer.log_type, Config.TELEPHONY)
+        self.assertIs(consumer.keys_to_labels, TELEPHONY_KEYS_TO_LABELS)
+
+    def test_activity_consumer(self):
+        consumer = ActivityConsumer(Config.JSON, "queue", "writer")
+        self.assertEqual(consumer.log_type, Config.ACTIVITY)
+        self.assertIs(consumer.keys_to_labels, ACTIVITY_KEYS_TO_LABELS)
+
+    def test_trustmonitor_consumer_inherits_empty_labels(self):
+        consumer = TrustMonitorConsumer(Config.JSON, "queue", "writer")
+        self.assertEqual(consumer.log_type, Config.TRUST_MONITOR)
+        self.assertEqual(consumer.keys_to_labels, {})

--- a/tests/test_consumer_consume.py
+++ b/tests/test_consumer_consume.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for Consumer.consume() (the queue→write→checkpoint loop and its
+error/branch paths) and the update_log_checkpoint file writer.
+"""
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import AsyncMock, patch
+
+from duologsync.config import Config
+from duologsync.consumer.consumer import Consumer
+from duologsync.program import Program
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _FakeQueue:
+    def __init__(self, items):
+        self._items = items
+        self.get_calls = 0
+
+    async def get(self):
+        self.get_calls += 1
+        return self._items
+
+
+def _consumer(items, writer):
+    consumer = Consumer(Config.JSON, _FakeQueue(items), writer)
+    consumer.log_type = "auth"
+    return consumer
+
+
+class TestConsume(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    @patch("duologsync.consumer.consumer.Consumer.update_log_checkpoint")
+    @patch("duologsync.consumer.consumer.Producer.get_log_offset", return_value="off")
+    @patch("duologsync.consumer.consumer.Program.is_running", side_effect=[True, True, False])
+    def test_happy_path_writes_and_checkpoints(self, _running, _offset, checkpoint):
+        writer = AsyncMock()
+        consumer = _consumer([{"a": 1}, {"b": 2}], writer)
+        run(consumer.consume())
+        self.assertEqual(writer.write.await_count, 2)
+        checkpoint.assert_called_once_with("auth", "off", None)
+
+    @patch("duologsync.consumer.consumer.Consumer.update_log_checkpoint")
+    @patch("duologsync.consumer.consumer.Producer.get_log_offset", return_value="off")
+    @patch("duologsync.consumer.consumer.Program.is_running", side_effect=[True, True, False])
+    def test_empty_logs_skips_write_and_checkpoint(self, _running, _offset, checkpoint):
+        writer = AsyncMock()
+        consumer = _consumer([], writer)
+        run(consumer.consume())
+        writer.write.assert_not_awaited()
+        checkpoint.assert_not_called()
+
+    @patch("duologsync.consumer.consumer.Consumer.update_log_checkpoint")
+    @patch("duologsync.consumer.consumer.Producer.get_log_offset", return_value="off")
+    @patch("duologsync.consumer.consumer.Program.is_running", side_effect=[True, True, False])
+    def test_oserror_triggers_shutdown(self, _running, _offset, _checkpoint):
+        writer = AsyncMock()
+        writer.write.side_effect = OSError(32, "Broken pipe")
+        consumer = _consumer([{"a": 1}], writer)
+        run(consumer.consume())
+        # The real Program.initiate_shutdown flips the class-level running flag.
+        self.assertFalse(Program._running)
+        # The write was attempted once before the OSError propagated.
+        self.assertEqual(writer.write.await_count, 1)
+
+    @patch("duologsync.consumer.consumer.Program.is_running", side_effect=[True, False, False])
+    def test_shutdown_after_get_continues(self, _running):
+        writer = AsyncMock()
+        consumer = _consumer([{"a": 1}], writer)
+        run(consumer.consume())
+        writer.write.assert_not_awaited()
+
+
+class TestUpdateLogCheckpoint(TestCase):
+    def test_writes_offset_without_child_account(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with patch(
+                "duologsync.consumer.consumer.Config.get_checkpoint_dir",
+                return_value=directory,
+            ):
+                Consumer.update_log_checkpoint("auth", 12345, None)
+                # Second call exercises the os.path.exists()==True log branch.
+                Consumer.update_log_checkpoint("auth", 67890, None)
+
+            checkpoint = Path(directory) / "auth_checkpoint_data.txt"
+            self.assertEqual(checkpoint.read_text(), json.dumps(67890) + "\n")
+
+    def test_writes_offset_with_child_account(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with patch(
+                "duologsync.consumer.consumer.Config.get_checkpoint_dir",
+                return_value=directory,
+            ):
+                Consumer.update_log_checkpoint("auth", 999, "child7")
+
+            checkpoint = Path(directory) / "auth_checkpoint_data_child7.txt"
+            self.assertEqual(checkpoint.read_text(), json.dumps(999) + "\n")

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for the base Producer: the produce() loop and its exception arms,
+add_logs_to_queue unwrapping, the base call_log_api, and the remaining
+get_log_offset branches.
+"""
+
+import asyncio
+import socket
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from duologsync.config import Config
+from duologsync.producer.producer import Producer
+from duologsync.program import Program, ProgramShutdownError
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+async def _async_noop(*_args, **_kwargs):
+    return None
+
+
+async def _invoke(partial):
+    return partial()
+
+
+def _bare_producer(**attrs):
+    producer = Producer.__new__(Producer)
+    producer.api_call = attrs.get("api_call", MagicMock())
+    producer.log_queue = attrs.get("log_queue", asyncio.Queue())
+    producer.log_type = attrs.get("log_type", "auth")
+    producer.account_id = attrs.get("account_id", None)
+    producer.url_path = attrs.get("url_path", None)
+    producer.log_offset = attrs.get("log_offset", 0)
+    # produce() logs `self.log_offset or self.mintime`; only subclasses set mintime.
+    producer.mintime = attrs.get("mintime", None)
+    return producer
+
+
+class TestProduceLoop(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    @patch("duologsync.producer.producer.restless_sleep", new=_async_noop)
+    @patch("duologsync.producer.producer.Config.get_api_timeout", return_value=120)
+    @patch("duologsync.producer.producer.Program.is_running", side_effect=[True, False])
+    def test_happy_iteration_enqueues_logs(self, _running, _timeout):
+        producer = _bare_producer()
+        producer.call_log_api = AsyncMock(return_value=["log1"])
+        producer.get_logs = MagicMock(return_value=["log1"])
+        producer.add_logs_to_queue = AsyncMock()
+        run(producer.produce())
+        producer.add_logs_to_queue.assert_awaited_once_with(["log1"])
+        # Terminal sentinel put to unblock the consumer.
+        self.assertEqual(producer.log_queue.get_nowait(), [])
+
+    @patch("duologsync.producer.producer.restless_sleep", new=_async_noop)
+    @patch("duologsync.producer.producer.Config.get_api_timeout", return_value=120)
+    @patch("duologsync.producer.producer.Program.is_running", side_effect=[True, False])
+    def test_no_logs_available(self, _running, _timeout):
+        producer = _bare_producer()
+        producer.call_log_api = AsyncMock(return_value=None)
+        producer.add_logs_to_queue = AsyncMock()
+        run(producer.produce())
+        producer.add_logs_to_queue.assert_not_awaited()
+
+    @patch("duologsync.producer.producer.restless_sleep", new=_async_noop)
+    @patch("duologsync.producer.producer.Config.get_api_timeout", return_value=120)
+    @patch("duologsync.producer.producer.Program.is_running", side_effect=[True, False])
+    def test_gaierror_arm_triggers_shutdown(self, _running, _timeout):
+        producer = _bare_producer()
+        producer.call_log_api = AsyncMock(side_effect=socket.gaierror(8, "bad host"))
+        producer.handle_address_info_error = MagicMock(return_value="reason")
+        run(producer.produce())
+        producer.handle_address_info_error.assert_called_once()
+        self.assertFalse(Program._running)
+
+    @patch("duologsync.producer.producer.restless_sleep", new=_async_noop)
+    @patch("duologsync.producer.producer.Config.get_api_timeout", return_value=120)
+    @patch("duologsync.producer.producer.Program.is_running", side_effect=[True, False])
+    def test_oserror_arm_triggers_shutdown(self, _running, _timeout):
+        producer = _bare_producer()
+        producer.call_log_api = AsyncMock(side_effect=OSError(5, "io"))
+        producer.handle_os_error = MagicMock(return_value="reason")
+        run(producer.produce())
+        producer.handle_os_error.assert_called_once()
+        self.assertFalse(Program._running)
+
+    @patch("duologsync.producer.producer.restless_sleep", new=_async_noop)
+    @patch("duologsync.producer.producer.Config.get_api_timeout", return_value=120)
+    @patch("duologsync.producer.producer.Program.is_running", side_effect=[True, False])
+    def test_runtime_error_arm(self, _running, _timeout):
+        producer = _bare_producer()
+        producer.call_log_api = AsyncMock(side_effect=RuntimeError("boom"))
+        producer.handle_runtime_error_gracefully = MagicMock(return_value="reason")
+        run(producer.produce())
+        producer.handle_runtime_error_gracefully.assert_called_once()
+        self.assertFalse(Program._running)
+
+    @patch("duologsync.producer.producer.Config.get_api_timeout", return_value=120)
+    @patch("duologsync.producer.producer.Program.is_running", side_effect=[True, True])
+    def test_program_shutdown_error_breaks(self, _running, _timeout):
+        producer = _bare_producer()
+        with patch(
+            "duologsync.producer.producer.restless_sleep",
+            side_effect=ProgramShutdownError,
+        ):
+            run(producer.produce())
+        # Loop broke out; terminal sentinel still enqueued.
+        self.assertEqual(producer.log_queue.get_nowait(), [])
+
+
+class TestAddLogsToQueue(TestCase):
+    @patch("duologsync.producer.producer.Producer.get_log_offset", return_value="off")
+    def test_unwraps_authlogs(self, _offset):
+        producer = _bare_producer(log_queue=asyncio.Queue())
+        run(producer.add_logs_to_queue({"authlogs": [1, 2]}))
+        self.assertEqual(producer.log_queue.get_nowait(), [1, 2])
+
+    @patch("duologsync.producer.producer.Producer.get_log_offset", return_value="off")
+    def test_unwraps_events(self, _offset):
+        producer = _bare_producer(log_queue=asyncio.Queue())
+        run(producer.add_logs_to_queue({"events": [3]}))
+        self.assertEqual(producer.log_queue.get_nowait(), [3])
+
+    @patch("duologsync.producer.producer.Producer.get_log_offset", return_value="off")
+    def test_unwraps_items(self, _offset):
+        producer = _bare_producer(log_queue=asyncio.Queue())
+        run(producer.add_logs_to_queue({"items": [4]}))
+        self.assertEqual(producer.log_queue.get_nowait(), [4])
+
+    @patch("duologsync.producer.producer.Producer.get_log_offset", return_value="off")
+    def test_empty_logs_enqueues_nothing(self, _offset):
+        producer = _bare_producer(log_queue=asyncio.Queue())
+        run(producer.add_logs_to_queue([]))
+        self.assertTrue(producer.log_queue.empty())
+
+
+class TestCallLogApiBase(TestCase):
+    def tearDown(self):
+        Config._config = None
+        Config._config_is_set = False
+
+    @patch("duologsync.producer.producer.run_in_executor", _invoke)
+    @patch("duologsync.producer.producer.Config.account_is_msp", return_value=False)
+    def test_non_msp(self, _msp):
+        api_call = MagicMock(return_value="R")
+        producer = _bare_producer(api_call=api_call, log_offset=123)
+        self.assertEqual(run(producer.call_log_api()), "R")
+        self.assertEqual(api_call.call_args.kwargs["mintime"], 123)
+
+    @patch("duologsync.producer.producer.run_in_executor", _invoke)
+    @patch("duologsync.producer.producer.Config.account_is_msp", return_value=True)
+    def test_msp(self, _msp):
+        api_call = MagicMock(return_value="R")
+        producer = _bare_producer(api_call=api_call, log_offset=5, account_id="acc", url_path="/p")
+        run(producer.call_log_api())
+        kwargs = api_call.call_args.kwargs
+        self.assertEqual(kwargs["method"], "GET")
+        self.assertEqual(kwargs["path"], "/p")
+        self.assertEqual(kwargs["params"]["account_id"], "acc")
+
+
+class TestGetLogOffsetBranches(TestCase):
+    def test_get_logs_passthrough(self):
+        self.assertEqual(Producer.get_logs("x"), "x")
+
+    def test_activity_response_with_next_offset(self):
+        log = {"items": [1], "metadata": {"next_offset": "abc"}}
+        self.assertEqual(Producer.get_log_offset(log, log_type=Config.ACTIVITY), "abc")
+
+    def test_trustmonitor_events_list_uses_last_surfaced(self):
+        log = {"events": [{"surfaced": 100}, {"surfaced": 200}], "metadata": {}}
+        self.assertEqual(Producer.get_log_offset(log, log_type=Config.TRUST_MONITOR), 201)
+
+    def test_dict_timestamp_plus_one(self):
+        self.assertEqual(Producer.get_log_offset({"timestamp": 50}), 51)
+
+    def test_dict_no_match_returns_current(self):
+        self.assertEqual(Producer.get_log_offset({}, current_log_offset="X"), "X")
+
+    def test_non_dict_uses_last_timestamp(self):
+        self.assertEqual(Producer.get_log_offset([{"timestamp": 9}]), 10)

--- a/tests/test_producer_subclasses.py
+++ b/tests/test_producer_subclasses.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for the producer subclasses: offset handling in __init__ and the
+parameters each call_log_api builds. run_in_executor is patched to invoke the
+functools.partial synchronously so the recorded api_call kwargs can be asserted
+without touching a real Duo Admin client or thread pool.
+"""
+
+import asyncio
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from duologsync.config import Config
+from duologsync.producer.activity_producer import ActivityProducer
+from duologsync.producer.authlog_producer import AuthlogProducer
+from duologsync.producer.telephony_producer import TelephonyProducer
+from duologsync.producer.trustmonitor_producer import TrustMonitorProducer
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+async def _invoke(partial):
+    # Stand-in for run_in_executor: call the partial synchronously.
+    return partial()
+
+
+class _ProducerTestBase(TestCase):
+    def setUp(self):
+        Config.set_config(
+            {
+                "dls_settings": {
+                    "checkpointing": {"enabled": False, "directory": "/tmp"},
+                    "api": {"offset": 100},
+                },
+                "account": {"is_msp": False},
+            }
+        )
+
+    def tearDown(self):
+        Config._config = None
+        Config._config_is_set = False
+
+
+class TestAuthlogProducer(_ProducerTestBase):
+    def test_int_offset_sets_mintime(self):
+        producer = AuthlogProducer(MagicMock(), None)
+        # api offset 100 * 1000 (auth is millisecond-based) -> int -> mintime.
+        self.assertEqual(producer.mintime, 100000)
+        self.assertIsNone(producer.log_offset)
+
+    @patch("duologsync.producer.producer.get_log_offset", return_value=(1, 2))
+    def test_tuple_offset_keeps_log_offset(self, _offset):
+        producer = AuthlogProducer(MagicMock(), None)
+        self.assertIsNone(producer.mintime)
+        self.assertEqual(producer.log_offset, (1, 2))
+
+    @patch("duologsync.producer.authlog_producer.run_in_executor", _invoke)
+    def test_call_log_api_non_msp(self):
+        api_call = MagicMock(return_value="RESULT")
+        producer = AuthlogProducer(api_call, None)
+        result = run(producer.call_log_api())
+        self.assertEqual(result, "RESULT")
+        kwargs = api_call.call_args.kwargs
+        self.assertEqual(kwargs["api_version"], 2)
+        self.assertEqual(kwargs["sort"], "ts:asc")
+        self.assertEqual(kwargs["limit"], "1000")
+
+    @patch("duologsync.producer.authlog_producer.run_in_executor", _invoke)
+    @patch("duologsync.producer.authlog_producer.Config.account_is_msp", return_value=True)
+    def test_call_log_api_msp(self, _msp):
+        api_call = MagicMock(return_value="RESULT")
+        producer = AuthlogProducer(api_call, None, child_account_id="child9", url_path="/admin/v2/logs/authentication")
+        run(producer.call_log_api())
+        kwargs = api_call.call_args.kwargs
+        self.assertEqual(kwargs["method"], "GET")
+        self.assertEqual(kwargs["path"], "/admin/v2/logs/authentication")
+        self.assertIn(b"account_id", kwargs["params"])
+
+
+class TestTelephonyProducer(_ProducerTestBase):
+    @patch("duologsync.producer.producer.get_log_offset", return_value="500,txid")
+    def test_string_offset_splits_mintime(self, _offset):
+        producer = TelephonyProducer(MagicMock(), None)
+        self.assertEqual(producer.mintime, 500)
+        self.assertIsNone(producer.log_offset)
+
+    @patch("duologsync.producer.telephony_producer.run_in_executor", _invoke)
+    def test_call_log_api_builds_params(self):
+        api_call = MagicMock(return_value="RESULT")
+        producer = TelephonyProducer(api_call, None, url_path="/admin/v2/logs/telephony")
+        producer.log_offset = "9999"  # exercise the next_offset branch
+        run(producer.call_log_api())
+        params = api_call.call_args.kwargs["params"]
+        self.assertIn(b"mintime", params)
+        self.assertIn(b"maxtime", params)
+        # next_offset is added after normalize_params, so it is a plain str key.
+        self.assertIn("next_offset", params)
+
+
+class TestActivityProducer(_ProducerTestBase):
+    @patch("duologsync.producer.activity_producer.run_in_executor", _invoke)
+    def test_call_log_api_builds_params(self):
+        api_call = MagicMock(return_value="RESULT")
+        producer = ActivityProducer(api_call, None, url_path="/admin/v2/logs/activity")
+        run(producer.call_log_api())
+        params = api_call.call_args.kwargs["params"]
+        self.assertIn(b"mintime", params)
+        self.assertIn(b"maxtime", params)
+        self.assertTrue(producer.first_pass)  # activity does not consume first_pass
+
+
+class TestTrustMonitorProducer(_ProducerTestBase):
+    @patch("duologsync.producer.trustmonitor_producer.run_in_executor", _invoke)
+    def test_first_pass_forces_null_offset(self):
+        api_call = MagicMock(return_value="RESULT")
+        producer = TrustMonitorProducer(api_call, None)
+        self.assertTrue(producer.first_pass)
+        run(producer.call_log_api())
+        self.assertFalse(producer.first_pass)
+        kwargs = api_call.call_args.kwargs
+        self.assertIsNone(kwargs["offset"])
+        self.assertIn("mintime", kwargs)
+        self.assertIn("maxtime", kwargs)
+
+    @patch("duologsync.producer.trustmonitor_producer.run_in_executor", _invoke)
+    def test_advance_promotes_offset_to_mintime(self):
+        api_call = MagicMock(return_value="RESULT")
+        producer = TrustMonitorProducer(api_call, None)
+        producer.first_pass = False
+        producer.mintime = 100
+        producer.log_offset = 200  # greater than mintime -> promote
+        run(producer.call_log_api())
+        self.assertEqual(producer.mintime, 200)
+        self.assertIsNone(producer.log_offset)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for the Windows service wrapper (duologsync/service.py).
+
+pywin32 is not installed on the CI platform, so fake win32serviceutil/
+win32service/win32event/servicemanager/winreg modules are injected into
+sys.modules and the module is reloaded so _WIN32_AVAILABLE is True and the
+DuoLogSyncService class exists. The pure Windows event-loop glue is exercised
+against these fakes; only the ``__main__`` block is pragma-excluded.
+"""
+
+import importlib
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+service = None
+_saved = {}
+
+
+class _FakeServiceFramework:
+    def __init__(self, args=None):
+        self.args = args
+
+    def ReportServiceStatus(self, status):
+        self.status = status
+
+
+def setUpModule():
+    global service, _saved
+    win32serviceutil = MagicMock()
+    win32serviceutil.ServiceFramework = _FakeServiceFramework
+    fakes = {
+        "win32serviceutil": win32serviceutil,
+        "win32service": MagicMock(),
+        "win32event": MagicMock(),
+        "servicemanager": MagicMock(),
+        "winreg": MagicMock(),
+    }
+    for name, module in fakes.items():
+        _saved[name] = sys.modules.get(name)
+        sys.modules[name] = module
+    sys.modules.pop("duologsync.service", None)
+    service = importlib.import_module("duologsync.service")
+    service = importlib.reload(service)
+
+
+def tearDownModule():
+    for name, module in _saved.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+    # Restore the plain (no-win32) module for any later importers.
+    sys.modules.pop("duologsync.service", None)
+    importlib.import_module("duologsync.service")
+
+
+class TestRegistryHelpers(TestCase):
+    def test_get_config_path_success(self):
+        service.winreg.QueryValueEx.return_value = ("C:\\cfg.yml", 1)
+        self.assertEqual(service._get_config_path_from_registry(), "C:\\cfg.yml")
+
+    def test_get_config_path_oserror_becomes_runtimeerror(self):
+        service.winreg.OpenKey.side_effect = OSError("access denied")
+        with self.assertRaises(RuntimeError):
+            service._get_config_path_from_registry()
+        service.winreg.OpenKey.side_effect = None
+
+    def test_set_config_path_success(self):
+        service.winreg.CreateKey.side_effect = None
+        service._set_config_path_in_registry("C:\\cfg.yml")
+        service.winreg.SetValueEx.assert_called()
+
+    def test_set_config_path_oserror_becomes_runtimeerror(self):
+        service.winreg.CreateKey.side_effect = OSError("not admin")
+        with self.assertRaises(RuntimeError):
+            service._set_config_path_in_registry("C:\\cfg.yml")
+        service.winreg.CreateKey.side_effect = None
+
+
+class TestMain(TestCase):
+    def test_not_available_exits_one(self):
+        with patch.object(service, "_WIN32_AVAILABLE", False):
+            with patch.object(sys, "argv", ["duologsync-service", "start"]):
+                with self.assertRaises(SystemExit) as ctx:
+                    service.main()
+        self.assertEqual(ctx.exception.code, 1)
+
+    @patch("os.path.isfile", return_value=True)
+    @patch("os.path.abspath", side_effect=lambda p: p)
+    def test_install_with_config(self, _abspath, _isfile):
+        with patch.object(service, "_set_config_path_in_registry") as set_reg:
+            with patch.object(service.win32serviceutil, "HandleCommandLine") as handle:
+                with patch.object(sys, "argv", ["svc", "install", "--config", "cfg.yml"]):
+                    service.main()
+        handle.assert_called_once()
+        set_reg.assert_called_once_with("cfg.yml")
+
+    def test_install_missing_config_exits_one(self):
+        with patch.object(sys, "argv", ["svc", "install"]):
+            with self.assertRaises(SystemExit) as ctx:
+                service.main()
+        self.assertEqual(ctx.exception.code, 1)
+
+    @patch("os.path.isfile", return_value=False)
+    @patch("os.path.abspath", side_effect=lambda p: p)
+    def test_install_file_not_found_exits_one(self, _abspath, _isfile):
+        with patch.object(sys, "argv", ["svc", "install", "--config", "missing.yml"]):
+            with self.assertRaises(SystemExit) as ctx:
+                service.main()
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_non_install_passthrough(self):
+        with patch.object(service.win32serviceutil, "HandleCommandLine") as handle:
+            with patch.object(sys, "argv", ["svc", "start"]):
+                service.main()
+        handle.assert_called_once()
+
+    @patch("os.path.isfile", return_value=True)
+    @patch("os.path.abspath", side_effect=lambda p: p)
+    def test_install_registry_warning_is_swallowed(self, _abspath, _isfile):
+        with patch.object(service, "_set_config_path_in_registry", side_effect=RuntimeError("nope")):
+            with patch.object(service.win32serviceutil, "HandleCommandLine"):
+                with patch.object(sys, "argv", ["svc", "install", "--config", "cfg.yml"]):
+                    service.main()  # RuntimeError caught -> warning printed, no exit
+
+
+class TestServiceMethods(TestCase):
+    def tearDown(self):
+        from duologsync.program import Program
+
+        Program._running = True
+
+    def _instance(self):
+        return service.DuoLogSyncService(None)
+
+    def test_svc_stop_initiates_shutdown(self):
+        from duologsync.program import Program
+
+        svc = self._instance()
+        svc.SvcStop()
+        self.assertFalse(Program._running)
+        service.win32event.SetEvent.assert_called()
+
+    def test_svc_do_run_success(self):
+        svc = self._instance()
+        with patch.object(service, "_get_config_path_from_registry", return_value="cfg.yml"):
+            with patch("duologsync.app.run") as run_mock:
+                svc.SvcDoRun()
+        run_mock.assert_called_once_with("cfg.yml")
+
+    def test_svc_do_run_config_error_returns(self):
+        svc = self._instance()
+        with patch.object(service, "_get_config_path_from_registry", side_effect=RuntimeError("no cfg")):
+            with patch("duologsync.app.run") as run_mock:
+                svc.SvcDoRun()
+        run_mock.assert_not_called()
+        service.servicemanager.LogErrorMsg.assert_called()
+
+    def test_svc_do_run_app_error_is_logged(self):
+        svc = self._instance()
+        with patch.object(service, "_get_config_path_from_registry", return_value="cfg.yml"):
+            with patch("duologsync.app.run", side_effect=Exception("boom")):
+                svc.SvcDoRun()
+        service.servicemanager.LogErrorMsg.assert_called()

--- a/tests/test_util_helpers.py
+++ b/tests/test_util_helpers.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for the remaining duologsync.util helpers: restless_sleep,
+run_in_executor, create_admin, normalize_params, and the get_log_offset
+checkpoint-success path.
+"""
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from duologsync.config import Config
+from duologsync.program import Program, ProgramShutdownError
+from duologsync.util import (
+    create_admin,
+    get_log_offset,
+    normalize_params,
+    restless_sleep,
+    run_in_executor,
+)
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class TestRestlessSleep(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    def test_completes_while_running(self):
+        Program._running = True
+        with patch("duologsync.util.asyncio.sleep", new=_async_noop):
+            # duration=1 -> one mocked sleep, still running, returns None.
+            self.assertIsNone(run(restless_sleep(1)))
+
+    def test_raises_when_shutting_down(self):
+        Program._running = False
+        with patch("duologsync.util.asyncio.sleep", new=_async_noop):
+            with self.assertRaises(ProgramShutdownError):
+                run(restless_sleep(5))
+
+
+async def _async_noop(*_args, **_kwargs):
+    return None
+
+
+class TestRunInExecutor(TestCase):
+    def test_runs_callable_and_returns_result(self):
+        self.assertEqual(run(run_in_executor(lambda: 42)), 42)
+
+
+class TestCreateAdmin(TestCase):
+    @patch("duologsync.util.duo_client.Accounts")
+    @patch("duologsync.util.duo_client.Admin")
+    def test_non_msp_uses_admin(self, admin_cls, accounts_cls):
+        create_admin("ikey", "skey", "api.example.com")
+        admin_cls.assert_called_once()
+        accounts_cls.assert_not_called()
+        _, kwargs = admin_cls.call_args
+        self.assertEqual(kwargs["ikey"], "ikey")
+        self.assertEqual(kwargs["host"], "api.example.com")
+
+    @patch("duologsync.util.duo_client.Accounts")
+    @patch("duologsync.util.duo_client.Admin")
+    def test_msp_uses_accounts(self, admin_cls, accounts_cls):
+        create_admin("ikey", "skey", "api.example.com", is_msp=True)
+        accounts_cls.assert_called_once()
+        admin_cls.assert_not_called()
+
+    @patch("duologsync.util.duo_client.Admin")
+    def test_proxy_is_configured_when_both_set(self, admin_cls):
+        admin = create_admin("i", "s", "h", proxy_server="proxy", proxy_port=8080)
+        admin.set_proxy.assert_called_once_with(host="proxy", port=8080)
+
+    @patch("duologsync.util.duo_client.Admin")
+    def test_proxy_not_configured_when_missing(self, admin_cls):
+        admin = create_admin("i", "s", "h", proxy_server="proxy", proxy_port=None)
+        admin.set_proxy.assert_not_called()
+
+
+class TestNormalizeParams(TestCase):
+    def test_string_value_becomes_encoded_list(self):
+        self.assertEqual(normalize_params({"a": "x"}), {b"a": [b"x"]})
+
+    def test_none_value_becomes_single_none_list(self):
+        self.assertEqual(normalize_params({"b": None}), {b"b": [None]})
+
+    def test_list_values_are_encoded_elementwise(self):
+        self.assertEqual(normalize_params({"c": ["y", "z"]}), {b"c": [b"y", b"z"]})
+
+
+class TestGetLogOffsetSuccess(TestCase):
+    def tearDown(self):
+        Config._config = None
+        Config._config_is_set = False
+        Program._running = True
+
+    def setUp(self):
+        Config.set_config({"dls_settings": {"api": {"offset": 1000}}})
+
+    def test_reads_offset_from_checkpoint_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "auth_checkpoint_data.txt"
+            checkpoint.write_text(json.dumps(123456789))
+            offset = get_log_offset("auth", recover_log_offset=True, checkpoint_directory=directory)
+            self.assertEqual(offset, 123456789)
+
+    def test_reads_child_account_checkpoint_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "auth_checkpoint_data_child42.txt"
+            checkpoint.write_text(json.dumps([1000, "txid"]))
+            offset = get_log_offset(
+                "auth",
+                recover_log_offset=True,
+                checkpoint_directory=directory,
+                child_account_id="child42",
+            )
+            self.assertEqual(offset, [1000, "txid"])
+
+    def test_missing_checkpoint_falls_back_to_api_offset(self):
+        with tempfile.TemporaryDirectory() as directory:
+            # No file present -> OSError path -> returns the (scaled) api offset.
+            offset = get_log_offset("auth", recover_log_offset=True, checkpoint_directory=directory)
+            # auth is millisecond-based: 1000 * 1000.
+            self.assertEqual(offset, 1000 * 1000)
+
+    def test_non_recover_returns_scaled_offset(self):
+        offset = get_log_offset("auth", recover_log_offset=False, checkpoint_directory="/nonexistent")
+        self.assertEqual(offset, 1000 * 1000)

--- a/tests/test_writer_more.py
+++ b/tests/test_writer_more.py
@@ -1,0 +1,388 @@
+"""
+Coverage for the remaining writer.py surface: DatagramProtocol, the network
+Writer factory/connection/shutdown paths, the FILE/inject wrappers, and the
+LocalFileWriter worker/replay/rotation edge branches. No real network is used
+(asyncio.open_connection / ssl are patched; UDP uses an unconnected socket).
+"""
+
+import asyncio
+import socket
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from duologsync.config import Config
+from duologsync.program import Program
+from duologsync.writer import DatagramProtocol, LocalFileWriter, Writer
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _writer_config(directory):
+    return {
+        "config_file_path": "cfg.yml",
+        "dls_settings": {
+            "checkpointing": {"directory": directory, "enabled": True},
+            "file_output": {
+                "queue_max_size": 100,
+                "max_retries": 1,
+                "retry_backoff_seconds": 0,
+                "enable_test_input": False,
+                "rotation": "none",
+                "max_bytes": 1000,
+                "rotation_interval": "daily",
+                "backup_count": 3,
+            },
+        },
+    }
+
+
+def _net_writer(protocol):
+    writer = Writer.__new__(Writer)
+    writer.protocol = protocol
+    writer.hostname = "127.0.0.1"
+    writer.port = 8888
+    writer.writer = None
+    return writer
+
+
+def _file_writer(directory, **overrides):
+    params = {
+        "filepath": str(Path(directory) / "out.log"),
+        "checkpoint_directory": directory,
+        "queue_max_size": 100,
+        "max_retries": 1,
+        "retry_backoff_seconds": 0,
+        "enable_test_input": False,
+        "rotation": "none",
+    }
+    params.update(overrides)
+    return LocalFileWriter(**params)
+
+
+class TestDatagramProtocol(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    def test_connection_made_sets_transport(self):
+        proto = DatagramProtocol("h", 5)
+        sentinel = object()
+        proto.connection_made(sentinel)
+        self.assertIs(proto.transport, sentinel)
+
+    def test_connection_lost_without_exc_shuts_down(self):
+        DatagramProtocol("h", 5).connection_lost(None)
+        self.assertFalse(Program._running)
+
+    def test_connection_lost_with_exc_shuts_down(self):
+        DatagramProtocol("h", 5).connection_lost(Exception("boom"))
+        self.assertFalse(Program._running)
+
+
+class TestCreateWriter(TestCase):
+    def tearDown(self):
+        Config._config = None
+        Config._config_is_set = False
+        Program._running = True
+
+    def _set_config(self, directory):
+        Config.set_config(_writer_config(directory))
+
+    def test_udp_returns_socket(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("UDP")
+            result = run(writer.create_writer("127.0.0.1", 8888, None))
+            self.assertIsInstance(result, socket.socket)
+            result.close()
+
+    @patch("duologsync.writer.asyncio.open_connection")
+    def test_tcp_success(self, open_conn):
+        open_conn.return_value = (MagicMock(), "STREAM")
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("TCP")
+            result = run(writer.create_writer("127.0.0.1", 8888, None))
+            self.assertEqual(result, "STREAM")
+
+    @patch("duologsync.writer.ssl.create_default_context")
+    @patch("duologsync.writer.asyncio.open_connection")
+    def test_tcpssl_success(self, open_conn, _ctx):
+        open_conn.return_value = (MagicMock(), "SSL_STREAM")
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("TCPSSL")
+            result = run(writer.create_writer("h", 8888, "cert.pem"))
+            self.assertEqual(result, "SSL_STREAM")
+
+    @patch("duologsync.writer.ssl.create_default_context", side_effect=FileNotFoundError(2, "no cert", "cert.pem"))
+    def test_tcpssl_missing_cert_shuts_down(self, _ctx):
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("TCPSSL")
+            result = run(writer.create_writer("h", 8888, "cert.pem"))
+            self.assertIsNone(result)
+            self.assertFalse(Program._running)
+
+    @patch("duologsync.writer.asyncio.open_connection", side_effect=asyncio.TimeoutError)
+    def test_tcp_timeout_shuts_down(self, _open):
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("TCP")
+            result = run(writer.create_writer("h", 8888, None))
+            self.assertIsNone(result)
+            self.assertFalse(Program._running)
+
+    @patch("duologsync.writer.asyncio.open_connection", side_effect=OSError(111, "refused"))
+    def test_tcp_connect_error_shuts_down(self, _open):
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("TCP")
+            result = run(writer.create_writer("h", 8888, None))
+            self.assertIsNone(result)
+            self.assertFalse(Program._running)
+
+    def test_file_success_returns_localfilewriter(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("FILE")
+            result = run(writer.create_writer(None, None, None, str(Path(directory) / "out.log")))
+            self.assertIsInstance(result, LocalFileWriter)
+
+    def test_file_invalid_path_shuts_down(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self._set_config(directory)
+            writer = _net_writer("FILE")
+            # Pointing at the directory itself -> IsADirectoryError -> shutdown.
+            result = run(writer.create_writer(None, None, None, directory))
+            self.assertIsNone(result)
+            self.assertFalse(Program._running)
+
+
+class TestCreateTcpWriter(TestCase):
+    @patch("duologsync.writer.asyncio.open_connection")
+    def test_returns_writer_half(self, open_conn):
+        open_conn.return_value = (MagicMock(), "STREAM")
+        self.assertEqual(run(Writer.create_tcp_writer("h", 1)), "STREAM")
+
+
+class TestCreateWriters(TestCase):
+    @patch.object(Writer, "create_writer", new=AsyncMock(return_value="STUB"))
+    def test_maps_server_id_to_writer(self):
+        writers = Writer.create_writers([{"id": "s1", "protocol": "TCP", "hostname": "h", "port": 1}])
+        self.assertIn("s1", writers)
+        self.assertEqual(writers["s1"].writer, "STUB")
+
+
+class TestWriterShutdown(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    def test_no_writer_returns(self):
+        writer = _net_writer("TCP")
+        writer.writer = None
+        run(writer.shutdown())  # no error
+
+    def test_udp_close_swallows_oserror(self):
+        writer = _net_writer("UDP")
+        writer.writer = MagicMock()
+        writer.writer.close.side_effect = OSError("boom")
+        run(writer.shutdown())
+        writer.writer.close.assert_called_once()
+
+    def test_file_delegates_shutdown(self):
+        writer = _net_writer("FILE")
+        writer.writer = AsyncMock()
+        run(writer.shutdown())
+        writer.writer.shutdown.assert_awaited_once()
+
+    def test_tcp_closes_and_waits(self):
+        writer = _net_writer("TCP")
+        writer.writer = MagicMock()
+        writer.writer.wait_closed = AsyncMock()
+        run(writer.shutdown())
+        writer.writer.close.assert_called_once()
+        writer.writer.wait_closed.assert_awaited_once()
+
+    @patch("duologsync.writer.asyncio.wait_for", side_effect=asyncio.TimeoutError)
+    def test_tcp_close_timeout_is_logged(self, _wait):
+        writer = _net_writer("TCP")
+        writer.writer = MagicMock()
+        writer.writer.wait_closed = AsyncMock()
+        run(writer.shutdown())  # TimeoutError swallowed with a warning
+
+    def test_tcp_close_oserror_is_logged(self):
+        writer = _net_writer("TCP")
+        writer.writer = MagicMock()
+        writer.writer.close.side_effect = OSError(9, "bad fd")
+        run(writer.shutdown())  # OSError swallowed with a warning
+
+    def test_shutdown_writers_awaits_all(self):
+        w1, w2 = AsyncMock(), AsyncMock()
+        run(Writer.shutdown_writers({"a": w1, "b": w2}))
+        w1.shutdown.assert_awaited_once()
+        w2.shutdown.assert_awaited_once()
+
+
+class TestWriterFileWrappers(TestCase):
+    def test_write_file_delegates(self):
+        writer = _net_writer("FILE")
+        writer.writer = AsyncMock()
+        run(writer.write(b"x", "auth"))
+        writer.writer.write.assert_awaited_once_with(b"x", "auth")
+
+    def test_write_file_none_is_noop(self):
+        writer = _net_writer("FILE")
+        writer.writer = None
+        run(writer.write(b"x", "auth"))  # no error
+
+    def test_register_log_type_file_delegates(self):
+        writer = _net_writer("FILE")
+        writer.writer = MagicMock()
+        writer.register_log_type("auth")
+        writer.writer.register_log_type.assert_called_once_with("auth")
+
+    def test_inject_test_data_non_file_raises(self):
+        writer = _net_writer("TCP")
+        with self.assertRaises(RuntimeError):
+            run(writer.inject_test_data("auth", [b"x"]))
+
+    def test_inject_test_data_no_writer_raises(self):
+        writer = _net_writer("FILE")
+        writer.writer = None
+        with self.assertRaises(RuntimeError):
+            run(writer.inject_test_data("auth", [b"x"]))
+
+    def test_inject_test_data_file_delegates(self):
+        writer = _net_writer("FILE")
+        writer.writer = AsyncMock()
+        run(writer.inject_test_data("auth", [b"x"]))
+        writer.writer.inject_test_data.assert_awaited_once()
+
+
+class TestLocalFileWriterInject(TestCase):
+    def test_disabled_raises(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory, enable_test_input=False)
+            with self.assertRaises(RuntimeError):
+                run(writer.inject_test_data("auth", ["x"]))
+
+    def test_enabled_appends_newline_and_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory, enable_test_input=True)
+            writer.write = AsyncMock()
+
+            async def scenario():
+                await writer.inject_test_data("auth", ["hello"])
+
+            run(scenario())
+            writer.write.assert_awaited_once_with(b"hello\n", "auth")
+
+
+class TestLocalFileWriterWorkerAndReplay(TestCase):
+    def tearDown(self):
+        Program._running = True
+
+    def test_initialize_log_type_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory)
+            writer._replay_backlog = AsyncMock()
+
+            async def scenario():
+                await writer._initialize_log_type("auth")
+                await writer._initialize_log_type("auth")
+
+            run(scenario())
+            writer._replay_backlog.assert_awaited_once()
+
+    def test_process_queue_backlogs_failed_write(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory)
+            writer._write_with_retries = AsyncMock(return_value=(False, True))
+            writer._append_backlog = AsyncMock()
+
+            async def scenario():
+                writer.queue.put_nowait(("auth", b"x\n"))
+                writer.queue.put_nowait(writer._STOP)
+                await writer._process_queue()
+
+            run(scenario())
+            writer._append_backlog.assert_awaited_once()
+
+    def test_process_queue_logs_item_exception(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory)
+            writer._write_with_retries = AsyncMock(side_effect=RuntimeError("boom"))
+
+            async def scenario():
+                writer.queue.put_nowait(("auth", b"x\n"))
+                writer.queue.put_nowait(writer._STOP)
+                await writer._process_queue()
+
+            run(scenario())  # exception logged, loop reaches STOP without crashing
+
+    def test_process_queue_outer_crash_shuts_down(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory)
+            crashing = MagicMock()
+            crashing.get = AsyncMock(side_effect=RuntimeError("queue broke"))
+            writer.queue = crashing
+            run(writer._process_queue())
+            self.assertFalse(Program._running)
+
+    def test_replay_backlog_file_partial_failure_preserves_remaining(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory)
+            replay = Path(directory) / "auth_file_failed_ingestion_logs.txt.replay"
+            replay.write_bytes(b"line-1\nline-2\n")
+            # First write "fails" so replay pauses and re-appends remaining lines.
+            writer._write_with_retries = AsyncMock(return_value=(False, True))
+
+            result = run(writer._replay_backlog_file("auth", replay))
+            self.assertFalse(result)
+            backlog = writer._backlog_path("auth")
+            self.assertTrue(backlog.exists())
+
+    def test_replay_backlog_file_read_error_returns_false(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory)
+            # Passing a directory as the replay path makes open() raise OSError.
+            result = run(writer._replay_backlog_file("auth", Path(directory)))
+            self.assertFalse(result)
+
+
+class TestLocalFileWriterRotationEdges(TestCase):
+    def test_empty_file_is_not_rotated(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory, rotation="size", max_bytes=1)
+            writer.filepath.write_bytes(b"")  # zero bytes
+            writer._maybe_rotate(10)  # returns early, no exception
+            self.assertEqual(list(writer.filepath.parent.glob("out.log.*")), [])
+
+    def test_rotation_check_failure_is_swallowed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory, rotation="size", max_bytes=1)
+            writer.filepath.write_bytes(b"data")
+            with patch.object(type(writer.filepath), "stat", side_effect=OSError("stat failed")):
+                writer._maybe_rotate(10)  # WARNING logged, swallowed
+
+    def test_prune_backups_none_count_returns(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory)
+            writer.backup_count = None
+            writer._prune_backups()  # no error
+
+    def test_prune_backups_swallows_unlink_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = _file_writer(directory, backup_count=0)
+            for i in range(2):
+                (writer.filepath.parent / f"out.log.2020-01-0{i}_000000").write_bytes(b"old")
+            with patch.object(Path, "unlink", side_effect=OSError("nope")):
+                writer._prune_backups()  # swallowed


### PR DESCRIPTION
## Summary

Raises test coverage from **57% → ~94%** (branch coverage on) and locks it in with a **`--cov-fail-under=90`** CI gate, so new code must ship with tests.

Eight new test modules cover the previously-untested async loops, network paths, and platform glue:

| Module | Focus | Result |
|---|---|---|
| `test_util_helpers.py` | restless_sleep, run_in_executor, create_admin, normalize_params, get_log_offset success | util 98% |
| `test_consumer/test_subclasses.py`, `test_consumer_consume.py` | subclass wiring, `consume()` loop, `update_log_checkpoint` | consumer 98% |
| `test_producer.py`, `test_producer_subclasses.py` | `produce()` arms, `add_logs_to_queue`, per-endpoint `call_log_api` | producer 98% |
| `test_writer_more.py` | DatagramProtocol, network Writer connect/shutdown, FILE/inject wrappers, worker/replay/rotation edges | writer 90%+ |
| `test_app_more.py` | signal_handler, main(), run() branches, every endpoint pair | app 99% |
| `test_service.py` | Windows service via fake win32/winreg + module reload | service 97% |

## Approach
- Async is driven with a per-test event loop (no pytest-asyncio); network is mocked (`asyncio.open_connection`/`ssl` patched, unconnected UDP socket); `service.py` is tested on Linux by injecting fake `win32*`/`winreg` modules into `sys.modules` and reloading.
- Only genuinely un-runnable glue is excluded: the `service.py __main__` block (`# pragma: no cover`) and the `exclude_also` defaults. Everything else is a real test.

## Config
- `pyproject.toml`: `[tool.coverage.report] exclude_also`.
- `.github/workflows/ci.yml`: test step now runs `--cov-fail-under=90`.

## Testing
- `uv run pytest --cov=duologsync --cov-fail-under=90` → **218 passed, TOTAL 93.51%**, gate satisfied.
- `uv run ruff check .` and `uv run ruff format --check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
