### PR TITLE
docs: add community-health files and fold long README sections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for MarkTripod-Duo/duo_log_sync
+# These owners are requested for review on every pull request.
+# See https://docs.github.com/articles/about-code-owners
+
+*       @MarkTripod-Duo

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug report
+description: Report a problem with Duo Log Sync (this unofficial fork)
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+
+        ⚠️ **Do not report security vulnerabilities here.** Please follow the
+        [security policy](../security/policy) instead.
+
+        This is an independent fork and is **not supported by Duo Security**.
+  - type: input
+    id: version
+    attributes:
+      label: Duo Log Sync version
+      description: Output of `duologsync --version` or the value in `duologsync/__version__.py`.
+      placeholder: "2.5.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - uv
+        - pip
+        - System service (systemd/OpenRC/SysVinit/launchd/Windows)
+    validations:
+      required: true
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: Output protocol
+      description: Which server protocol were you using?
+      options:
+        - TCP
+        - TCPSSL
+        - UDP
+        - FILE
+        - Not applicable
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Configure ...
+        2. Run `duologsync config.yml`
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste program logs (default `/tmp/duologsync.log`). This is automatically formatted as code.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration (redacted)
+      description: Your `config.yml` with all secrets removed.
+      render: yaml
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed my `ikey`, `skey`, and any other secrets from everything pasted above.
+          required: true
+        - label: This is not a security vulnerability (those go through the security policy).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Duo Admin API documentation
+    url: https://duo.com/docs/adminapi
+    about: "Reference for credentials, endpoints, and permissions. Duo does not support this fork."
+  - name: Report a security vulnerability
+    url: https://github.com/MarkTripod-Duo/duo_log_sync/security/advisories/new
+    about: "Please report vulnerabilities privately — do not open a public issue."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an idea or enhancement for Duo Log Sync
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! This is an independent fork and is
+        **not supported by Duo Security** — requests here are for this project only.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what is getting in the way?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or change you would like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you have tried or thought about.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that would help — examples, links, or config snippets.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Thanks for contributing! Please fill out the sections below.
+See CONTRIBUTING.md for setup, testing, and conventions.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] CI / tooling
+- [ ] Refactor / cleanup
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## How was this tested?
+
+<!-- Commands run, scenarios exercised, platforms checked. -->
+
+## Checklist
+
+- [ ] `uv run pytest` passes locally
+- [ ] `uv run ruff check .` and `uv run ruff format --check .` are clean
+- [ ] Coverage stays at or above the 90% gate (`--cov-fail-under=90`)
+- [ ] Tests added or updated for the change
+- [ ] Docs / README updated if behavior or usage changed
+- [ ] I have read and followed [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # GitHub Actions used by the CI and release workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Python dependencies managed by uv (reads pyproject.toml + uv.lock).
+  # If the "uv" ecosystem is not available, change this to "pip".
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,9 @@ dmypy.json
 .pytest_cache/
 
 .DS_Store
-config.yml
+# The user's Duo config at the repo root only — anchored so it does not match
+# .github/ISSUE_TEMPLATE/config.yml or other config.yml files in the tree.
+/config.yml
 
 # Claude Code local session / worktree artifacts
 .claude/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ an individual is officially representing the community in public spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**`<MAINTAINER CONTACT — e.g. an email address or a GitHub private report>`**.
+**`66480604+MarkTripod-Duo@users.noreply.github.com`**.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**`<MAINTAINER CONTACT — e.g. an email address or a GitHub private report>`**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+Thanks for your interest in improving Duo Log Sync! This is an independent fork;
+contributions are welcome here (not against `duosecurity/duo_log_sync`).
+
+## Development setup
+
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and dependency
+management.
+
+```bash
+# Install uv: https://docs.astral.sh/uv/getting-started/installation/
+uv sync --dev        # create the venv and install runtime + dev dependencies
+```
+
+## Running tests, lint, and formatting
+
+```bash
+uv run pytest                                   # run the test suite
+uv run pytest --cov=duologsync --cov-report=term-missing   # with coverage
+uv run ruff check .                             # lint
+uv run ruff format .                            # auto-format
+uv run ruff format --check .                    # verify formatting (CI does this)
+```
+
+### Coverage gate
+
+CI enforces **`--cov-fail-under=90`** — the test job fails if total coverage
+drops below 90%. New code should ship with tests that keep coverage at or above
+that line. Run the coverage command above before opening a PR.
+
+## Branch and commit conventions
+
+- Branch off `main` using a descriptive prefix: `feat/…`, `fix/…`, `test/…`,
+  `chore/…`, `docs/…`, or `ci/…`.
+- Write clear, imperative commit messages (a short subject plus a body when the
+  change needs explanation).
+- Keep unrelated changes in separate PRs.
+
+## Pull requests
+
+- Open PRs against `main`. The [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+  is applied automatically — please complete it.
+- CI (`.github/workflows/ci.yml`) runs ruff, the test matrix across Python
+  3.8–3.13, a build check, and the coverage gate. All checks must pass.
+- Update the `README.md` when you change behavior, configuration, or usage.
+
+## Reporting bugs and requesting features
+
+Use the issue templates (Bug report / Feature request). For **security
+vulnerabilities**, follow the [security policy](SECURITY.md) instead of opening
+a public issue.
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE) and that you follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ For FILE output, ensure the configured destination directory is accessible to th
 
 ## Installation
 
+<details>
+<summary><b>Installation options (uv, pip, Windows) — click to expand</b></summary>
+
 ### Using uv (Recommended)
 
 [uv](https://docs.astral.sh/uv/) is the recommended way to install and manage DuoLogSync.
@@ -123,9 +126,14 @@ The command exits with code `0` on success or `1` if errors are found, making it
 ### Windows
 - On Windows operating systems, `duologsync` is installed in the `\Scripts\` folder under the Python installation in most cases when using pip. When using uv, the application is available via `uv run duologsync`.
 
+</details>
+
 ---
 
 ## Running as a Service
+
+<details>
+<summary><b>Service setup for Linux, macOS, and Windows — click to expand</b></summary>
 
 DuoLogSync can be installed as a system service so it starts automatically and runs in the background.
 
@@ -217,6 +225,8 @@ duologsync-service debug     # run interactively for troubleshooting
 ```
 
 The config file path is stored in the Windows registry. The service appears as "Duo Log Sync" in the Services management console.
+
+</details>
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+> **This is an independent, community-maintained fork of
+> [`duosecurity/duo_log_sync`](https://github.com/duosecurity/duo_log_sync) and is
+> NOT covered by Duo Security's or Cisco's security process.** Reports here are
+> handled by this project's maintainer on a best-effort basis.
+>
+> A vulnerability in the **Duo product or the Duo Admin API itself** should be
+> reported to Duo/Cisco through their official channels, not here.
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| 2.5.x   | ✅        |
+| < 2.5   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability** (Security advisories → New draft advisory),
+   or use this link:
+   <https://github.com/MarkTripod-Duo/duo_log_sync/security/advisories/new>
+3. Include a description, affected version, reproduction steps, and impact.
+
+Please give a reasonable time for a fix before any public disclosure.
+
+## Handling secrets
+
+Duo Log Sync consumes Duo Admin API credentials (`ikey`/`skey`). When sharing
+logs or configuration in an advisory or issue, **always redact** integration
+keys, secret keys, hostnames, and any captured log data.


### PR DESCRIPTION
## Summary

Adds the standard GitHub community-health files the repo was missing and folds the two longest README sections so the page is easier to scan. Docs/config only — no source changes.

## New files

- **`.github/CODEOWNERS`** — `* @MarkTripod-Duo` so every PR requests review.
- **Issue forms** — `bug_report.yml` (version/OS/install-method/protocol fields + a *redact your ikey/skey* checkbox), `feature_request.yml`, and `config.yml` (disables blank issues; links to the Duo Admin API docs and the security policy; reinforces that Duo does not support this fork).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist tied to the repo's gates: pytest, ruff, and the 90% coverage floor.
- **`.github/dependabot.yml`** — weekly `github-actions` + `uv` update PRs.
- **`SECURITY.md`** — private vulnerability reporting via GitHub advisories; explicit note that this fork is **not** covered by Duo/Cisco's security process, and a reminder to redact `ikey`/`skey`.
- **`CONTRIBUTING.md`** — uv setup, tests, ruff, the coverage gate, and branch/PR conventions.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1. ⚠️ The enforcement contact is a `<MAINTAINER CONTACT>` placeholder — please fill it in.

## README

Wrapped **Installation** and **Running as a Service** in collapsible `<details>` blocks; the `##` headings stay visible and no wording changed.

## Also fixed

The `.gitignore` entry `config.yml` (for the user's root Duo config) was matching `.github/ISSUE_TEMPLATE/config.yml` and silently excluding it. Anchored it to `/config.yml`.

## Testing

- All `.github/**/*.yml` parse; `<details>` tags balanced (2 open / 2 close).
- `uv run pytest` → 218 passed; `uv run ruff check .` clean (unchanged — no code touched).

## Follow-ups for the maintainer

- Fill the Code of Conduct enforcement contact.
- Enable **Private vulnerability reporting** in repo Settings → Security so the SECURITY.md advisory link works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
